### PR TITLE
Allow PHP 8, update PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.0"
+        "php": "^7.0 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": "^7.0 || ^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^2.5",
         "jakub-onderka/php-parallel-lint": "^0.9.2",
         "phing/phing": "^2.13"

--- a/tests/Chances/StandardChanceTest.php
+++ b/tests/Chances/StandardChanceTest.php
@@ -8,7 +8,7 @@ class StandardChanceTest extends \PHPUnit\Framework\TestCase
      */
     private $chance;
 
-    public function setUp()
+    public function setup(): void
     {
         $this->chance = new StandardChance();
     }

--- a/tests/LaboratoryTest.php
+++ b/tests/LaboratoryTest.php
@@ -33,20 +33,20 @@ class LaboratoryTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(Report::class, $r);
         $this->assertEquals('foo', $r->getControl()->getValue());
         $this->assertEquals('bar', $r->getTrial('trial')->getValue());
-        $this->assertInternalType('float', $r->getControl()->getStartTime());
-        $this->assertInternalType('float', $r->getControl()->getEndTime());
-        $this->assertInternalType('float', $r->getControl()->getTime());
-        $this->assertInternalType('float', $r->getTrial('trial')->getStartTime());
-        $this->assertInternalType('float', $r->getTrial('trial')->getEndTime());
-        $this->assertInternalType('float', $r->getTrial('trial')->getTime());
-        $this->assertInternalType('integer', $r->getControl()->getStartMemory());
-        $this->assertInternalType('integer', $r->getControl()->getEndMemory());
-        $this->assertInternalType('integer', $r->getControl()->getMemory());
-        $this->assertInternalType('integer', $r->getTrial('trial')->getStartMemory());
-        $this->assertInternalType('integer', $r->getTrial('trial')->getEndMemory());
-        $this->assertInternalType('integer', $r->getTrial('trial')->getMemory());
-        $this->assertInternalType('null', $r->getControl()->getException());
-        $this->assertInternalType('null', $r->getTrial('trial')->getException());
+        $this->assertIsFloat($r->getControl()->getStartTime());
+        $this->assertIsFloat($r->getControl()->getEndTime());
+        $this->assertIsFloat($r->getControl()->getTime());
+        $this->assertIsFloat($r->getTrial('trial')->getStartTime());
+        $this->assertIsFloat($r->getTrial('trial')->getEndTime());
+        $this->assertIsFloat($r->getTrial('trial')->getTime());
+        $this->assertIsInt($r->getControl()->getStartMemory());
+        $this->assertIsInt($r->getControl()->getEndMemory());
+        $this->assertIsInt($r->getControl()->getMemory());
+        $this->assertIsInt($r->getTrial('trial')->getStartMemory());
+        $this->assertIsInt($r->getTrial('trial')->getEndMemory());
+        $this->assertIsInt($r->getTrial('trial')->getMemory());
+        $this->assertNull($r->getControl()->getException());
+        $this->assertNull($r->getTrial('trial')->getException());
         $this->assertFalse($r->getTrial('trial')->isMatch());
     }
 
@@ -70,7 +70,7 @@ class LaboratoryTest extends \PHPUnit\Framework\TestCase
             ->report();
 
         $this->assertInstanceOf(Report::class, $r);
-        $this->assertInternalType('null', $r->getControl()->getException());
+        $this->assertNull($r->getControl()->getException());
         $this->assertInstanceOf(Exception::class, $r->getTrial('trial')->getException());
     }
 

--- a/tests/MachineTest.php
+++ b/tests/MachineTest.php
@@ -93,8 +93,8 @@ class MachineTest extends \PHPUnit\Framework\TestCase
         $r = $m->execute();
         $e = microtime(true) + 60;
 
-        $this->assertInternalType('float', $r->getStartTime());
-        $this->assertInternalType('float', $r->getEndTime());
+        $this->assertIsFloat($r->getStartTime());
+        $this->assertIsFloat($r->getEndTime());
         $this->assertGreaterThan($s, $r->getStartTime());
         $this->assertGreaterThan($s, $r->getEndTime());
         $this->assertLessThan($e, $r->getStartTime());
@@ -107,7 +107,7 @@ class MachineTest extends \PHPUnit\Framework\TestCase
 
         $r = $m->execute();
 
-        $this->assertInternalType('integer', $r->getStartMemory());
-        $this->assertInternalType('integer', $r->getEndMemory());
+        $this->assertIsInt($r->getStartMemory());
+        $this->assertIsInt($r->getEndMemory());
     }
 }


### PR DESCRIPTION
The upstream package doesn't explicitly support PHP 8 even though it works fine -- it just required some test updates because PHPUnit had to be updated as well.

This will support us [loading the latest package from GitHub](https://getcomposer.org/doc/05-repositories.md#loading-a-package-from-a-vcs-repository).